### PR TITLE
Add FB Share Button

### DIFF
--- a/config_sample.php
+++ b/config_sample.php
@@ -10,14 +10,20 @@
 
 global $baseURI;
 global $basepath;
+global $nodeExecPath;
 global $zenserpkey;
 global $IPInfotoken;
 global $pushovertoken;
+global $isPushEnabled;
 global $googleAnalyticsId;
+global $fbAppId;
 
 $baseURI =  "";          // example: https://yourwebsite
 $basepath = "";          // filesystem path (no trailing slash necessary)
+$nodeExecPath = "";      // path to node executable (ex. "/usr/bin/node")
 $zenserpkey = "";        // API Key from Zenserp (for doing Google Image search results)
 $IPInfotoken = "";       // API Key from IP Info (for looking up IP addresses of visitors)
 $pushovertoken = "";     // API Key from Pushover (for sending push notifications of site activity)
+$isPushEnabled = False;  // Send user actions via Pushover if True
 $googleAnalyticsId = ""; // Google Analytics tracking id (provided to frontend for GA tracking)
+$fbAppId = "";           // Facebook App Id registered for this app. Required to use JS SDK and Share button.

--- a/index.php
+++ b/index.php
@@ -9,6 +9,7 @@ global $baseURI;
 require('sources/datausa.php');
 require('sources/google.php');
 require('sources/esm.php');
+require('utils/constants.php');
 
 $action = @$_GET['action'];
 
@@ -69,6 +70,7 @@ if($action == 'doPNG') {
 
 
     global $baseURI;
+    global $nodeExecPath;
 
     $id = $_GET['id']; //todo: sanitize input
     $src = $_GET['src'];
@@ -99,7 +101,7 @@ if($action == 'doPNG') {
     }
 
         // todo so much user sanitization it's not even funny
-        $args = "/usr/bin/node screenshot.js " . escapeshellarg($HTMLURI) . " " . escapeshellarg($PNGpath);
+        $args = $nodeExecPath . " screenshot.js " . escapeshellarg($HTMLURI) . " " . escapeshellarg($PNGpath);
         debug("Trying " . $args . " <hr />");
         exec($args, $output);
         //echo implode("\n", $output);

--- a/sources/datausa.php
+++ b/sources/datausa.php
@@ -311,7 +311,7 @@ function nice_number($n) {
 function array_kmerge ($array) {
   $start = 0;
 reset($array);
-while ($tmp = each($array))
+while ($tmp = @each($array))
 {
   if(count($tmp['value']) > 0)
   {

--- a/templates/generated_saved.html
+++ b/templates/generated_saved.html
@@ -3,6 +3,12 @@
         <div class="heading-text heading-section">
             <h2>IMAGE GENERATED</h2>
             <span class="lead">Right click or tap and hold on the image below to save it to your device, or to share it on social media.</span>
+            <br>
+            <br>
+            <!-- FB share button -->
+            <button type="button" class="btn btn-light-hover" onclick="onFbShareClick()">
+              Share <i class="icon-facebook"></i>
+            </button>
         </div>
         <div id="finalImage">
             <img src="{PNGURI}" class="img-fluid rounded" alt="">

--- a/templates/header.html
+++ b/templates/header.html
@@ -1,21 +1,18 @@
 <!DOCTYPE html>
 <html lang="en">
 
-<head>
+  <head>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
     <meta name="author" content="Every Single Month" />
     <meta name="description" content="The Freedom Dividend would transform towns across America by giving every adult $1,000/mo. See how this would impact your community.">
-    <meta property="og:description" content="The Freedom Dividend would transform towns across America by giving every adult $1,000/mo. See how this would impact your community.">
-    <meta property="og:image" content="{BASEURI}/static/images/seth-dewey-EOlo15oy8Ks-unsplash-1920.jpg" />
 
 
     <meta name="twitter:card" content="summary" />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="{BASEURI}" />
     <meta property="og:title" content="Every Single Month" />
     <meta property="og:description" content="The Freedom Dividend would transform towns across America by giving every adult $1,000/mo. See how this would impact your community." />
-    <meta property="og:image" content="{BASEURI}/static/images/seth-dewey-EOlo15oy8Ks-unsplash-1920.jpg" />
+    <meta property="og:image" content="{OG_IMAGE}" />
 
 
     <link rel="shortcut icon" href="{BASEURI}/static/images/favicon.ico" />
@@ -193,8 +190,14 @@
             return Promise.resolve("Dummy response to keep the console quiet");
         }
 
-        function updateBGUser(imgSrc) {
-
+        function onFbShareClick() {
+          if (!FB) { return; }
+          FB.ui({
+            display: 'popup',
+            method: 'share',
+            href: window.location.href,
+            // quote: '', <- Set to populate initial text
+          }, function (response) { });
         }
 
 
@@ -207,6 +210,11 @@
 </head>
 
 <body>
+
+<!-- FB JS SDK -->
+<div id="fb-root"></div>
+<script async defer crossorigin="anonymous" src="https://connect.facebook.net/en_US/sdk.js#xfbml=1&autoLogAppEvents=1&version=v7.0&appId={FB_APP_ID}"></script>
+
 <!-- Body Inner -->
 <div class="body-inner">
     <!-- Header -->

--- a/templates/home.html
+++ b/templates/home.html
@@ -3,7 +3,7 @@
 <!-- Inspiro Slider -->
 <div id="slider" class="inspiro-slider slider-fullscreen dots-creative">
     <!-- Slide 1 -->
-    <div class="slide kenburns" data-bg-image="static/images/seth-dewey-EOlo15oy8Ks-unsplash-1920.jpg">
+    <div class="slide kenburns" data-bg-image="{SPLASH_IMG}">
         <div class="bg-overlay"></div>
         <div class="container">
             <div class="slide-captions text-center text-light">

--- a/utils/constants.php
+++ b/utils/constants.php
@@ -1,0 +1,6 @@
+<?php
+// Global Constants defined here
+define("DEFAULT_SPLASH_IMG_URL", "static/images/seth-dewey-EOlo15oy8Ks-unsplash-1920.jpg");
+
+
+?>


### PR DESCRIPTION
**Before deploying will have to set these configs**
$nodeExecPath 
$isPushEnabled
$fbAppId


Background:
To set the preview image for a FB share, the image has to already be available
and set on a page in the og:image meta tag for FB to scrape. For this to work with all generated PNGs
we have to find a way to set this in the share URL so that the uniquely created infographic shows
in the preview. (Can discuss w/ Allen)

For now, the FB share button just uses the same header image for the city.

Changes:
-Adds FB Share button to share current page after generating the infographic
-Adds config option to turn off sending Push notifications
-Adds config option to set node executable path
-Adds config option for Facebook App Id which is required to use their JS SDK
-Allow setting some global constants in utils/constants.php.  Just setting main slash image for now.